### PR TITLE
Use H2 for chunker-service tests

### DIFF
--- a/chunker-service/pom.xml
+++ b/chunker-service/pom.xml
@@ -34,5 +34,10 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/chunker-service/src/test/resources/application.yml
+++ b/chunker-service/src/test/resources/application.yml
@@ -1,0 +1,10 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+    driverClassName: org.h2.Driver
+    username: sa
+    password: password
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop


### PR DESCRIPTION
## Summary
- add H2 as a test dependency for chunker-service
- configure tests to use an in-memory H2 database

## Testing
- `mvn -q test` *(fails: could not resolve org.springframework.boot:spring-boot-dependencies:3.2.5 - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6892658882948320a1c75536efa9621f