### PR TITLE
Add H2 test configuration for embedding service

### DIFF
--- a/embedding-service/pom.xml
+++ b/embedding-service/pom.xml
@@ -35,5 +35,10 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/embedding-service/src/test/java/com/example/sec/embedding/EmbeddingServiceApplicationTests.java
+++ b/embedding-service/src/test/java/com/example/sec/embedding/EmbeddingServiceApplicationTests.java
@@ -2,8 +2,10 @@ package com.example.sec.embedding;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class EmbeddingServiceApplicationTests {
   @Test
   void contextLoads() {}

--- a/embedding-service/src/test/resources/application.yml
+++ b/embedding-service/src/test/resources/application.yml
@@ -1,0 +1,7 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create-drop


### PR DESCRIPTION
## Summary
- configure embedding service tests to use in-memory H2 database
- load test-specific properties via `@ActiveProfiles("test")