### PR TITLE
Add Elasticsearch host property for embedding tests

### DIFF
--- a/embedding-service/src/test/resources/application.yml
+++ b/embedding-service/src/test/resources/application.yml
@@ -5,3 +5,5 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop
+elasticsearch:
+  host: http://localhost:9200


### PR DESCRIPTION
## Summary
- add elasticsearch.host to embedding-service test config to satisfy context loading