### PR TITLE
Refactor ingestion pipeline to delegate parsing and chunking

### DIFF
--- a/chunker-service/src/main/java/com/example/sec/chunker/kafka/SectionListener.java
+++ b/chunker-service/src/main/java/com/example/sec/chunker/kafka/SectionListener.java
@@ -24,13 +24,20 @@ public class SectionListener {
     }
 
     @KafkaListener(topics = "${kafka.topic}")
-    public void handle(String content) {
-        Section section = new Section();
-        section.setContent(content);
-        section = chunkerService.save(section);
-        MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
-        map.add("sectionId", section.getId().toString());
-        map.add("content", section.getContent());
-        restTemplate.postForObject(embeddingBaseUrl + "/embeddings", map, Void.class);
+    public void handle(String text) {
+        String[] chunks = text.split("(?<=\\.)\\s+");
+        for (String chunk : chunks) {
+            String trimmed = chunk.trim();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            Section section = new Section();
+            section.setContent(trimmed);
+            section = chunkerService.save(section);
+            MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+            map.add("sectionId", section.getId().toString());
+            map.add("content", section.getContent());
+            restTemplate.postForObject(embeddingBaseUrl + "/embeddings", map, Void.class);
+        }
     }
 }

--- a/ingestion-service/pom.xml
+++ b/ingestion-service/pom.xml
@@ -22,11 +22,6 @@
       <version>8.5.2</version>
     </dependency>
     <dependency>
-      <groupId>org.jsoup</groupId>
-      <artifactId>jsoup</artifactId>
-      <version>1.15.3</version>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/ingestion-service/src/main/java/com/example/sec/ingestion/service/IngestionServiceImpl.java
+++ b/ingestion-service/src/main/java/com/example/sec/ingestion/service/IngestionServiceImpl.java
@@ -6,8 +6,8 @@ import io.minio.PutObjectArgs;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
-import org.jsoup.Jsoup;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
@@ -15,16 +15,24 @@ import org.springframework.web.client.RestTemplate;
 public class IngestionServiceImpl implements IngestionService {
   private final MinioClient minioClient;
   private final RestTemplate restTemplate;
+  private final KafkaTemplate<String, String> kafkaTemplate;
 
   @Value("${minio.bucket}")
   private String bucket;
 
-  @Value("${retrieval.base-url:http://localhost:8085}")
-  private String retrievalBaseUrl;
+  @Value("${parser.base-url:http://localhost:8082}")
+  private String parserBaseUrl;
 
-  public IngestionServiceImpl(MinioClient minioClient, RestTemplate restTemplate) {
+  @Value("${kafka.topic}")
+  private String topic;
+
+  public IngestionServiceImpl(
+      MinioClient minioClient,
+      RestTemplate restTemplate,
+      KafkaTemplate<String, String> kafkaTemplate) {
     this.minioClient = minioClient;
     this.restTemplate = restTemplate;
+    this.kafkaTemplate = kafkaTemplate;
   }
 
   @Override
@@ -46,15 +54,14 @@ public class IngestionServiceImpl implements IngestionService {
               .contentType("text/html")
               .build());
 
-      String text = Jsoup.parse(html).text();
-      String[] chunks = text.split("(?<=\\.)\\s+");
-      for (String chunk : chunks) {
-        String trimmed = chunk.trim();
-        if (trimmed.isEmpty()) {
-          continue;
+      Map<?, ?> parsed =
+          restTemplate.postForObject(
+              parserBaseUrl + "/parse?key=" + objectName, null, Map.class);
+      if (parsed != null) {
+        Object textObj = parsed.get("text");
+        if (textObj instanceof String text && !text.isEmpty()) {
+          kafkaTemplate.send(topic, text);
         }
-        restTemplate.postForObject(
-            retrievalBaseUrl + "/documents", Map.of("content", trimmed), String.class);
       }
     } catch (Exception e) {
       throw new RuntimeException("Failed to ingest filing", e);

--- a/ingestion-service/src/main/resources/application.yml
+++ b/ingestion-service/src/main/resources/application.yml
@@ -15,5 +15,5 @@ minio:
   secret-key: minioadmin
 kafka:
   topic: filings-parsed
-retrieval:
-  base-url: http://retrieval-service:8085
+parser:
+  base-url: http://parser-service:8082


### PR DESCRIPTION
## Summary
- Store raw filings in MinIO and forward parsing results to Kafka instead of chunking in ingestion-service
- Perform text chunking within chunker-service before persisting and embedding
- Remove unused HTML parsing dependency from ingestion-service