### PR TITLE
Index embeddings in Elasticsearch with JPA fallback

### DIFF
--- a/embedding-service/src/main/java/com/example/sec/embedding/service/EmbeddingServiceImpl.java
+++ b/embedding-service/src/main/java/com/example/sec/embedding/service/EmbeddingServiceImpl.java
@@ -1,6 +1,12 @@
 package com.example.sec.embedding.service;
 
+import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestHighLevelClient;
 import org.springframework.stereotype.Service;
 import com.example.sec.embedding.model.EmbeddingRecord;
 import com.example.sec.embedding.repository.EmbeddingRepository;
@@ -10,10 +16,14 @@ import opennlp.tools.tokenize.SimpleTokenizer;
 public class EmbeddingServiceImpl implements EmbeddingService {
   private final EmbeddingRepository repository;
   private final SimpleTokenizer tokenizer;
+  private final RestHighLevelClient esClient;
 
-  public EmbeddingServiceImpl(EmbeddingRepository repository, SimpleTokenizer tokenizer) {
+  public EmbeddingServiceImpl(EmbeddingRepository repository,
+                              SimpleTokenizer tokenizer,
+                              RestHighLevelClient esClient) {
     this.repository = repository;
     this.tokenizer = tokenizer;
+    this.esClient = esClient;
   }
 
   @Override
@@ -23,6 +33,19 @@ public class EmbeddingServiceImpl implements EmbeddingService {
     EmbeddingRecord record = new EmbeddingRecord();
     record.setSectionId(sectionId);
     record.setVectorId(vectorId);
+
+    try {
+      Map<String, Object> jsonMap = new HashMap<>();
+      jsonMap.put("sectionId", sectionId);
+      jsonMap.put("vectorId", vectorId);
+      IndexRequest request = new IndexRequest("sections")
+          .id(sectionId + ":" + vectorId)
+          .source(jsonMap);
+      esClient.index(request, RequestOptions.DEFAULT);
+    } catch (IOException e) {
+      // Log and continue saving to repository as fallback
+    }
+
     return repository.save(record);
   }
 }


### PR DESCRIPTION
## Summary
- Inject `RestHighLevelClient` into `EmbeddingServiceImpl` to enable Elasticsearch access.
- After computing a vector, index a `sections` document keyed by `sectionId` and `vectorId`.
- Gracefully handle indexing failures while still persisting records via JPA.