### PR TITLE
Propagate filing metadata through ingestion and chunking pipeline

### DIFF
--- a/chunker-service/src/main/java/com/example/sec/chunker/kafka/SectionListener.java
+++ b/chunker-service/src/main/java/com/example/sec/chunker/kafka/SectionListener.java
@@ -2,6 +2,7 @@ package com.example.sec.chunker.kafka;
 
 import com.example.sec.chunker.model.Section;
 import com.example.sec.chunker.service.ChunkerService;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -14,35 +15,52 @@ import org.springframework.web.client.RestTemplate;
 public class SectionListener {
     private final ChunkerService chunkerService;
     private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
     private final String embeddingBaseUrl;
     private final String retrievalBaseUrl;
 
-    public SectionListener(ChunkerService chunkerService,
-                           RestTemplate restTemplate,
-                           @Value("${embedding.base-url:http://embedding-service:8084}") String embeddingBaseUrl,
-                           @Value("${retrieval.base-url:http://retrieval-service:8085}") String retrievalBaseUrl) {
+    public SectionListener(
+            ChunkerService chunkerService,
+            RestTemplate restTemplate,
+            ObjectMapper objectMapper,
+            @Value("${embedding.base-url:http://embedding-service:8084}") String embeddingBaseUrl,
+            @Value("${retrieval.base-url:http://retrieval-service:8085}") String retrievalBaseUrl) {
         this.chunkerService = chunkerService;
         this.restTemplate = restTemplate;
+        this.objectMapper = objectMapper;
         this.embeddingBaseUrl = embeddingBaseUrl;
         this.retrievalBaseUrl = retrievalBaseUrl;
     }
 
     @KafkaListener(topics = "${kafka.topic}")
-    public void handle(String text) {
-        String[] chunks = text.split("(?<=\\.)\\s+");
-        for (String chunk : chunks) {
-            String trimmed = chunk.trim();
-            if (trimmed.isEmpty()) {
-                continue;
+    public void handle(String payload) {
+        try {
+            Map<?, ?> parsed = objectMapper.readValue(payload, Map.class);
+            Object textObj = parsed.get("text");
+            if (!(textObj instanceof String text) || text.isEmpty()) {
+                return;
             }
-            Section section = new Section();
-            section.setContent(trimmed);
-            section = chunkerService.save(section);
-            MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
-            map.add("sectionId", section.getId().toString());
-            map.add("content", section.getContent());
-            restTemplate.postForObject(embeddingBaseUrl + "/embeddings", map, Void.class);
-            restTemplate.postForObject(retrievalBaseUrl + "/sections", section, Void.class);
+            String cik = (String) parsed.get("cik");
+            String formType = (String) parsed.get("formType");
+            String[] chunks = text.split("(?<=\\.)\\s+");
+            for (String chunk : chunks) {
+                String trimmed = chunk.trim();
+                if (trimmed.isEmpty()) {
+                    continue;
+                }
+                Section section = new Section();
+                section.setContent(trimmed);
+                section.setCik(cik);
+                section.setType(formType);
+                section = chunkerService.save(section);
+                MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
+                map.add("sectionId", section.getId().toString());
+                map.add("content", section.getContent());
+                restTemplate.postForObject(embeddingBaseUrl + "/embeddings", map, Void.class);
+                restTemplate.postForObject(retrievalBaseUrl + "/sections", section, Void.class);
+            }
+        } catch (Exception e) {
+            // ignore malformed messages
         }
     }
 }

--- a/chunker-service/src/test/java/com/example/sec/chunker/kafka/SectionListenerTest.java
+++ b/chunker-service/src/test/java/com/example/sec/chunker/kafka/SectionListenerTest.java
@@ -2,10 +2,14 @@ package com.example.sec.chunker.kafka;
 
 import com.example.sec.chunker.model.Section;
 import com.example.sec.chunker.service.ChunkerService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -28,15 +32,32 @@ class SectionListenerTest {
         SectionListener listener = new SectionListener(
             chunkerService,
             restTemplate,
+            new ObjectMapper(),
             "http://embedding-service:8084",
             "http://retrieval-service:8085"
         );
 
-        listener.handle("First sentence. Second sentence.");
+        String json = "{" +
+            "\"cik\":\"0001\"," +
+            "\"formType\":\"10-K\"," +
+            "\"filingDate\":\"2023-01-01\"," +
+            "\"text\":\"First sentence. Second sentence.\"" +
+            "}";
+        listener.handle(json);
+
+        ArgumentCaptor<MultiValueMap<String, String>> embedCaptor = ArgumentCaptor.forClass(MultiValueMap.class);
+        ArgumentCaptor<Section> sectionCaptor = ArgumentCaptor.forClass(Section.class);
 
         verify(restTemplate, times(2))
-            .postForObject(eq("http://embedding-service:8084/embeddings"), any(MultiValueMap.class), eq(Void.class));
+            .postForObject(eq("http://embedding-service:8084/embeddings"), embedCaptor.capture(), eq(Void.class));
         verify(restTemplate, times(2))
-            .postForObject(eq("http://retrieval-service:8085/sections"), any(Section.class), eq(Void.class));
+            .postForObject(eq("http://retrieval-service:8085/sections"), sectionCaptor.capture(), eq(Void.class));
+
+        List<MultiValueMap<String, String>> embedMaps = embedCaptor.getAllValues();
+        assertThat(embedMaps.get(0).getFirst("content")).isEqualTo("First sentence.");
+
+        List<Section> sections = sectionCaptor.getAllValues();
+        assertThat(sections.get(0).getCik()).isEqualTo("0001");
+        assertThat(sections.get(0).getType()).isEqualTo("10-K");
     }
 }


### PR DESCRIPTION
## Summary
- Send Kafka messages as JSON including filing metadata from the ingestion service
- Parse JSON in the chunker listener, set section `cik` and `type`, and forward to downstream services
- Add tests verifying embedding payload content and metadata persistence in retrieval