### PR TITLE
Add filing date to sections

### DIFF
--- a/chunker-service/src/main/java/com/example/sec/chunker/kafka/SectionListener.java
+++ b/chunker-service/src/main/java/com/example/sec/chunker/kafka/SectionListener.java
@@ -42,6 +42,7 @@ public class SectionListener {
             }
             String cik = (String) parsed.get("cik");
             String formType = (String) parsed.get("formType");
+            String filingDate = (String) parsed.get("filingDate");
             String[] chunks = text.split("(?<=\\.)\\s+");
             for (String chunk : chunks) {
                 String trimmed = chunk.trim();
@@ -52,6 +53,7 @@ public class SectionListener {
                 section.setContent(trimmed);
                 section.setCik(cik);
                 section.setType(formType);
+                section.setFilingDate(filingDate);
                 section = chunkerService.save(section);
                 MultiValueMap<String, String> map = new LinkedMultiValueMap<>();
                 map.add("sectionId", section.getId().toString());

--- a/chunker-service/src/main/java/com/example/sec/chunker/model/Section.java
+++ b/chunker-service/src/main/java/com/example/sec/chunker/model/Section.java
@@ -12,6 +12,7 @@ public class Section {
   private String cik;
   private String type;
   private String content;
+  private String filingDate;
 
   public Long getId() { return id; }
   public void setId(Long id) { this.id = id; }
@@ -21,4 +22,6 @@ public class Section {
   public void setType(String type) { this.type = type; }
   public String getContent() { return content; }
   public void setContent(String content) { this.content = content; }
+  public String getFilingDate() { return filingDate; }
+  public void setFilingDate(String filingDate) { this.filingDate = filingDate; }
 }

--- a/chunker-service/src/test/java/com/example/sec/chunker/kafka/SectionListenerTest.java
+++ b/chunker-service/src/test/java/com/example/sec/chunker/kafka/SectionListenerTest.java
@@ -59,5 +59,6 @@ class SectionListenerTest {
         List<Section> sections = sectionCaptor.getAllValues();
         assertThat(sections.get(0).getCik()).isEqualTo("0001");
         assertThat(sections.get(0).getType()).isEqualTo("10-K");
+        assertThat(sections.get(0).getFilingDate()).isEqualTo("2023-01-01");
     }
 }

--- a/retrieval-service/src/main/java/com/example/sec/retrieval/model/Section.java
+++ b/retrieval-service/src/main/java/com/example/sec/retrieval/model/Section.java
@@ -12,6 +12,7 @@ public class Section {
   private String cik;
   private String type;
   private String content;
+  private String filingDate;
 
   public Long getId() { return id; }
   public void setId(Long id) { this.id = id; }
@@ -21,4 +22,6 @@ public class Section {
   public void setType(String type) { this.type = type; }
   public String getContent() { return content; }
   public void setContent(String content) { this.content = content; }
+  public String getFilingDate() { return filingDate; }
+  public void setFilingDate(String filingDate) { this.filingDate = filingDate; }
 }

--- a/retrieval-service/src/main/resources/data.sql
+++ b/retrieval-service/src/main/resources/data.sql
@@ -1,2 +1,2 @@
-INSERT INTO DOCUMENT (content) VALUES ('Revenue for 2023 was $5 million. Net income increased.');
-INSERT INTO DOCUMENT (content) VALUES ('Operating expenses were reduced by 10 percent.');
+INSERT INTO SECTION (cik, type, content, filing_date) VALUES ('0001', '10-K', 'Revenue for 2023 was $5 million. Net income increased.', '2023-01-01');
+INSERT INTO SECTION (cik, type, content, filing_date) VALUES ('0001', '10-K', 'Operating expenses were reduced by 10 percent.', '2023-01-02');

--- a/retrieval-service/src/test/java/com/example/sec/retrieval/RetrievalControllerTest.java
+++ b/retrieval-service/src/test/java/com/example/sec/retrieval/RetrievalControllerTest.java
@@ -36,9 +36,11 @@ class RetrievalControllerTest {
         repository.deleteAll();
         Section s1 = new Section();
         s1.setContent("Revenue was $5 million in 2023.");
+        s1.setFilingDate("2023-01-01");
         repository.save(s1);
         Section s2 = new Section();
         s2.setContent("Operating expenses decreased.");
+        s2.setFilingDate("2023-01-02");
         repository.save(s2);
     }
 
@@ -55,6 +57,7 @@ class RetrievalControllerTest {
         section.setCik("1234");
         section.setType("10-K");
         section.setContent("Test content");
+        section.setFilingDate("2023-01-03");
 
         mockMvc.perform(
                 post("/sections")
@@ -69,5 +72,6 @@ class RetrievalControllerTest {
         assertThat(saved).isPresent();
         assertThat(saved.get().getCik()).isEqualTo("1234");
         assertThat(saved.get().getType()).isEqualTo("10-K");
+        assertThat(saved.get().getFilingDate()).isEqualTo("2023-01-03");
     }
 }


### PR DESCRIPTION
## Summary
- track filing date on sections in chunker and retrieval services
- propagate filing date from Kafka messages through to persistence
- seed sample data with filing dates and extend tests