### PR TITLE
feat: support metadata filters in retrieval

### DIFF
--- a/qa-service/src/main/java/com/example/sec/qa/Answer.java
+++ b/qa-service/src/main/java/com/example/sec/qa/Answer.java
@@ -9,5 +9,5 @@ import java.util.List;
  * @param sources    the documents used as evidence
  * @param confidence confidence score between 0 and 1
  */
-public record Answer(String answer, List<String> sources, double confidence) {
+public record Answer(String answer, List<Section> sources, double confidence) {
 }

--- a/qa-service/src/main/java/com/example/sec/qa/QaController.java
+++ b/qa-service/src/main/java/com/example/sec/qa/QaController.java
@@ -1,13 +1,16 @@
 package com.example.sec.qa;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 import org.springframework.web.util.UriUtils;
 
 @RestController
@@ -25,12 +28,28 @@ public class QaController {
     }
 
     @GetMapping("/qa")
-    public Answer ask(@RequestParam String question) {
-        String url = retrievalBaseUrl + "/search?query=" + UriUtils.encode(question, StandardCharsets.UTF_8);
-        List<String> docs = restTemplate.getForObject(url, List.class);
-        if (docs == null) {
-            docs = Collections.emptyList();
-        }
+    public Answer ask(
+            @RequestParam String question,
+            @RequestParam(required = false) String cik,
+            @RequestParam(required = false) String formType,
+            @RequestParam(required = false) String filingDate) {
+        UriComponentsBuilder builder =
+                UriComponentsBuilder.fromHttpUrl(retrievalBaseUrl + "/search")
+                        .queryParam("query", UriUtils.encode(question, StandardCharsets.UTF_8))
+                        .queryParamIfPresent(
+                                "cik",
+                                Optional.ofNullable(cik)
+                                        .map(s -> UriUtils.encode(s, StandardCharsets.UTF_8)))
+                        .queryParamIfPresent(
+                                "formType",
+                                Optional.ofNullable(formType)
+                                        .map(s -> UriUtils.encode(s, StandardCharsets.UTF_8)))
+                        .queryParamIfPresent(
+                                "filingDate",
+                                Optional.ofNullable(filingDate)
+                                        .map(s -> UriUtils.encode(s, StandardCharsets.UTF_8)));
+        Section[] response = restTemplate.getForObject(builder.toUriString(), Section[].class);
+        List<Section> docs = response == null ? Collections.emptyList() : Arrays.asList(response);
         return reasoningService.generateAnswer(question, docs);
     }
 }

--- a/qa-service/src/main/java/com/example/sec/qa/ReasoningService.java
+++ b/qa-service/src/main/java/com/example/sec/qa/ReasoningService.java
@@ -31,7 +31,7 @@ public class ReasoningService {
      * @param documents  retrieved documents
      * @return answer with confidence score
      */
-    public Answer generateAnswer(String question, List<String> documents) {
+    public Answer generateAnswer(String question, List<Section> documents) {
         if (question == null) {
             question = "";
         }
@@ -46,11 +46,11 @@ public class ReasoningService {
         }
         double bestScore = 0.0;
         String bestSentence = null;
-        for (String doc : documents) {
-            if (doc == null) {
+        for (Section doc : documents) {
+            if (doc == null || doc.content() == null) {
                 continue;
             }
-            String[] sentences = doc.split("(?<=[.?!])\\s+");
+            String[] sentences = doc.content().split("(?<=[.?!])\\s+");
             for (String sentence : sentences) {
                 double score = similarity(question, sentence);
                 if (score > bestScore) {
@@ -72,10 +72,10 @@ public class ReasoningService {
     /**
      * Batch version of {@link #generateAnswer} for reduced overhead.
      */
-    public List<Answer> generateAnswers(List<String> questions, List<List<String>> documentsList) {
+    public List<Answer> generateAnswers(List<String> questions, List<List<Section>> documentsList) {
         List<Answer> results = new ArrayList<>();
         for (int i = 0; i < questions.size(); i++) {
-            List<String> docs = documentsList != null && i < documentsList.size()
+            List<Section> docs = documentsList != null && i < documentsList.size()
                 ? documentsList.get(i)
                 : Collections.emptyList();
             results.add(generateAnswer(questions.get(i), docs));

--- a/qa-service/src/main/java/com/example/sec/qa/Section.java
+++ b/qa-service/src/main/java/com/example/sec/qa/Section.java
@@ -1,0 +1,3 @@
+package com.example.sec.qa;
+
+public record Section(Long id, String cik, String type, String filingDate, String content) {}

--- a/retrieval-service/src/main/java/com/example/sec/retrieval/controller/RetrievalController.java
+++ b/retrieval-service/src/main/java/com/example/sec/retrieval/controller/RetrievalController.java
@@ -4,7 +4,6 @@ import com.example.sec.retrieval.model.Section;
 import com.example.sec.retrieval.repository.SectionRepository;
 import com.example.sec.retrieval.service.RetrievalService;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -23,10 +22,12 @@ public class RetrievalController {
     }
 
     @GetMapping("/search")
-    public List<String> search(@RequestParam String query) {
-        return retrievalService.search(query).stream()
-            .map(Section::getContent)
-            .collect(Collectors.toList());
+    public List<Section> search(
+            @RequestParam String query,
+            @RequestParam(required = false) String cik,
+            @RequestParam(required = false) String formType,
+            @RequestParam(required = false) String filingDate) {
+        return retrievalService.search(query, cik, formType, filingDate);
     }
 
     @PostMapping("/sections")

--- a/retrieval-service/src/main/java/com/example/sec/retrieval/model/Section.java
+++ b/retrieval-service/src/main/java/com/example/sec/retrieval/model/Section.java
@@ -11,6 +11,7 @@ public class Section {
   private Long id;
   private String cik;
   private String type;
+  private String filingDate;
   private String content;
 
   public Long getId() { return id; }
@@ -19,6 +20,8 @@ public class Section {
   public void setCik(String cik) { this.cik = cik; }
   public String getType() { return type; }
   public void setType(String type) { this.type = type; }
+  public String getFilingDate() { return filingDate; }
+  public void setFilingDate(String filingDate) { this.filingDate = filingDate; }
   public String getContent() { return content; }
   public void setContent(String content) { this.content = content; }
 }

--- a/retrieval-service/src/main/java/com/example/sec/retrieval/repository/SectionRepository.java
+++ b/retrieval-service/src/main/java/com/example/sec/retrieval/repository/SectionRepository.java
@@ -2,8 +2,21 @@ package com.example.sec.retrieval.repository;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import com.example.sec.retrieval.model.Section;
 
 public interface SectionRepository extends JpaRepository<Section, Long> {
-  List<Section> findByContentContainingIgnoreCase(String query);
+
+  @Query(
+      "SELECT s FROM Section s WHERE "
+          + "LOWER(s.content) LIKE LOWER(CONCAT('%', :query, '%')) "
+          + "AND (:cik IS NULL OR s.cik = :cik) "
+          + "AND (:formType IS NULL OR s.type = :formType) "
+          + "AND (:filingDate IS NULL OR s.filingDate = :filingDate)")
+  List<Section> search(
+      @Param("query") String query,
+      @Param("cik") String cik,
+      @Param("formType") String formType,
+      @Param("filingDate") String filingDate);
 }

--- a/retrieval-service/src/main/java/com/example/sec/retrieval/service/RetrievalService.java
+++ b/retrieval-service/src/main/java/com/example/sec/retrieval/service/RetrievalService.java
@@ -4,5 +4,5 @@ import java.util.List;
 import com.example.sec.retrieval.model.Section;
 
 public interface RetrievalService {
-  List<Section> search(String query);
+  List<Section> search(String query, String cik, String formType, String filingDate);
 }

--- a/retrieval-service/src/test/java/com/example/sec/retrieval/RetrievalControllerTest.java
+++ b/retrieval-service/src/test/java/com/example/sec/retrieval/RetrievalControllerTest.java
@@ -36,6 +36,9 @@ class RetrievalControllerTest {
         repository.deleteAll();
         Section s1 = new Section();
         s1.setContent("Revenue was $5 million in 2023.");
+        s1.setCik("1234");
+        s1.setType("10-K");
+        s1.setFilingDate("2023-02-03");
         repository.save(s1);
         Section s2 = new Section();
         s2.setContent("Operating expenses decreased.");
@@ -46,7 +49,21 @@ class RetrievalControllerTest {
     void searchReturnsMatchingSections() throws Exception {
         mockMvc.perform(get("/search").param("query", "revenue"))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("$[0]").value("Revenue was $5 million in 2023."));
+            .andExpect(jsonPath("$[0].content").value("Revenue was $5 million in 2023."));
+    }
+
+    @Test
+    void searchSupportsMetadataFilters() throws Exception {
+        mockMvc.perform(
+                get("/search")
+                    .param("query", "revenue")
+                    .param("cik", "1234")
+                    .param("formType", "10-K")
+                    .param("filingDate", "2023-02-03"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$[0].cik").value("1234"))
+            .andExpect(jsonPath("$[0].type").value("10-K"))
+            .andExpect(jsonPath("$[0].filingDate").value("2023-02-03"));
     }
 
     @Test
@@ -54,6 +71,7 @@ class RetrievalControllerTest {
         Section section = new Section();
         section.setCik("1234");
         section.setType("10-K");
+        section.setFilingDate("2023-01-01");
         section.setContent("Test content");
 
         mockMvc.perform(
@@ -69,5 +87,6 @@ class RetrievalControllerTest {
         assertThat(saved).isPresent();
         assertThat(saved.get().getCik()).isEqualTo("1234");
         assertThat(saved.get().getType()).isEqualTo("10-K");
+        assertThat(saved.get().getFilingDate()).isEqualTo("2023-01-01");
     }
 }


### PR DESCRIPTION
## Summary
- extend retrieval search API to accept optional cik, formType, and filingDate filters
- return full Section metadata and propagate richer results to QA service
- update reasoning logic to handle Section objects instead of raw strings

## Testing
- `mvn -q -pl retrieval-service,qa-service test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6896259a33cc83208facbc97cb220fe3